### PR TITLE
Bug is fixed related to the use of operators

### DIFF
--- a/quadratic.c
+++ b/quadratic.c
@@ -8,40 +8,32 @@ printf("Enter three numbers: \n");
 scanf("%f %f %f",&a,&b,&c);
 
 if((a==0) &&(b==0)){
-printf("invalid cofficients\n");
+  printf("invalid cofficients\n");
 }
 
 else {
-
-d= b*b-4*a*c;
-printf("tha value of d is: %.4f\n",d);
-
+  d= b*b-4*a*c;
+  printf("tha value of d is: %.4f\n",d);
 }
 
 if (d==0) {
-
-root1=root2=-b/(2*a);
-printf("the value of root1 is: %.4f\n the value of root2 is: %.4f\n",root1,root2);
-
+  root1=-b/(2*a);
+  root2=-b/(2*a);
+  printf("the value of root1 is: %.4f\n the value of root2 is: %.4f\n",root1,root2);
 }
 
 else if (d>0) {
-
-root1=(-b+sqrt(d))/(2*a);
-root2=(-b-sqrt(d))/(2*a);
-printf("the value of root1 is : %.4f\n the value of root2 is: %.4f\n",root1,root2);
+  root1=(-b+sqrt(d))/(2*a);
+  root2=(-b-sqrt(d))/(2*a);
+  printf("the value of root1 is : %.4f\n the value of root2 is: %.4f\n",root1,root2);
 }
 
 else {
-
-root1=-b/(2*a);
-root2 = sqrt(fabs(d))/(2*a);
-printf("the value of root1 is : %.4f +i %.4f\n",root1,root2);
-printf("the value of root2 is : %.4f -i %.4f\n",root1,root2);
-
+  root1=-b/(2*a);
+  root2 = sqrt(fabs(d))/(2*a);
+  printf("the value of root1 is : %.4f +i %.4f\n",root1,root2);
+  printf("the value of root2 is : %.4f -i %.4f\n",root1,root2);
 }
-
-
 
 return 0;
 }


### PR DESCRIPTION
Incorrect use of operators in C language. C language never uses a=b=c type for equating three values. These are done separately, i.e., a=b; b=c;
